### PR TITLE
Allow the feminine form for author and supervisor

### DIFF
--- a/main.typ
+++ b/main.typ
@@ -17,12 +17,12 @@
  Title and template
 */
 #import "template/_title.typ": *
-#_title(TBtitle, TBsubtitle, TBacademicYears, TBdpt, TBfiliere, TBorient, TBauthor, TBsupervisor, TBindustryContact, TBindustryName, TBindustryAddress, confidential)
+#_title(TBtitle, TBsubtitle, TBacademicYears, TBdpt, TBfiliere, TBorient, TBauthor, TBfeminineForm, TBsupervisor, TBsupervisorFeminineForm, TBindustryContact, TBindustryName, TBindustryAddress, confidential)
 #import "template/_second_title.typ": *
-#_second_title(TBtitle, TBacademicYears, TBdpt, TBfiliere, TBorient, TBauthor, TBsupervisor, TBindustryName, TBresumePubliable)
+#_second_title(TBtitle, TBacademicYears, TBdpt, TBfiliere, TBorient, TBauthor, TBfeminineForm, TBsupervisor, TBsupervisorFeminineForm, TBindustryName, TBresumePubliable)
 #include "template/_preambule.typ"
 #import "template/_authentification.typ": *
-#_authentification(TBauthor)
+#_authentification(TBauthor, TBfeminineForm)
 
 /*
  Cahier des charges

--- a/template/_authentification.typ
+++ b/template/_authentification.typ
@@ -1,8 +1,8 @@
-#let _authentification(TBauthor) = [
+#let _authentification(TBauthor, TBfeminineForm) = [
 #set par(leading: 0.55em, spacing: 0.55em, justify: true)
 = Authentification
 
-Le soussigné, #TBauthor, atteste par la présente avoir réalisé ce travail et n’avoir utilisé aucune autre source que celles expressément mentionnées
+#if TBfeminineForm { "La soussignée" } else { "Le soussigné" }, #TBauthor, atteste par la présente avoir réalisé ce travail et n’avoir utilisé aucune autre source que celles expressément mentionnées
 
 #v(10%)
 

--- a/template/_second_title.typ
+++ b/template/_second_title.typ
@@ -1,14 +1,14 @@
 #import "macros.typ": *
 
-#let _second_title(TBtitle, TBacademicYears, TBdpt, TBfiliere, TBorient, TBauthor, TBsupervisor, TBindustryName, TBresumePubliable) = {
+#let _second_title(TBtitle, TBacademicYears, TBdpt, TBfiliere, TBorient, TBauthor, TBfeminineForm, TBsupervisor, TBsupervisorFeminineForm, TBindustryName, TBresumePubliable) = {
   set par(leading: 0.55em, spacing: 0.55em, justify: true)
   pagebreak(to: "odd")
   align(right)[
     #TBdpt\
     #TBfiliere\
     #TBorient\
-    Étudiant : #TBauthor\
-    Enseignant responsable : #TBsupervisor\
+    #if TBfeminineForm { "Étudiante" } else { "Étudiant" } : #TBauthor\
+    #if TBsupervisorFeminineForm { "Enseignante" } else { "Enseignant" } responsable : #TBsupervisor\
   ]
 
   v(10%)
@@ -41,7 +41,7 @@
     columns: (40%, 30%, 30%),
     row-gutter: 1em,
     align: bottom,
-    [Étudiant :], [Date et lieu :], [Signature :],
+    [#if TBfeminineForm { "Étudiante" } else { "Étudiant" } :], [Date et lieu :], [Signature :],
     [#TBauthor], [#hr_dotted()], [#hr_dotted()]
   )
   v(2%)
@@ -50,7 +50,7 @@
     columns: (40%, 30%, 30%),
     row-gutter: 1em,
     align: bottom,
-    [Enseignant responsable :], [Date et lieu :], [Signature :],
+    [#if TBsupervisorFeminineForm { "Enseignante" } else { "Enseignant" } responsable :], [Date et lieu :], [Signature :],
     [#TBsupervisor], [#hr_dotted()], [#hr_dotted()]
   )
   v(2%)

--- a/template/_title.typ
+++ b/template/_title.typ
@@ -1,4 +1,4 @@
-#let _title(TBtitle, TBsubtitle, TBacademicYears, TBdpt, TBfiliere, TBorient, TBauthor, TBsupervisor, TBindustryContact, TBindustryName, TBindustryAddress, confidential) = {
+#let _title(TBtitle, TBsubtitle, TBacademicYears, TBdpt, TBfiliere, TBorient, TBauthor,TBfeminineForm, TBsupervisor, TBsupervisorFeminineForm, TBindustryContact, TBindustryName, TBindustryAddress, confidential) = {
   set par(leading: 0.55em, spacing: 0.55em, justify: true)
   columns(2, [
     #image("images/logo_heig-vd-2020.svg", width: 40%)
@@ -30,8 +30,8 @@
     #table(
       stroke: none,
       columns: (50%, 50%),
-      [*Étudiant*], [*#TBauthor*],
-      [*Enseignant responsable*], [#TBsupervisor],
+      [*#if TBfeminineForm { "Étudiante" } else { "Étudiant" }*], [*#TBauthor*],
+      [*#if TBsupervisorFeminineForm { "Enseignante" } else { "Enseignant" } responsable*], [#TBsupervisor],
       [*Entreprise mandante*], [
         #TBindustryContact \
         #TBindustryName \

--- a/vars.typ
+++ b/vars.typ
@@ -3,6 +3,10 @@
 #let studentFirstname = "stuFirstname"
 #let studentLastname = "stuLastname"
 
+// Use feminine or masculine form in template's text. Example: "La soussignée" or "Le soussigné"
+#let TBfeminineForm = false // for the author
+#let TBsupervisorFeminineForm = false // same, but for the supervisor. Example: "Enseignante responsable"
+
 #let confidential = true
 
 #let TBtitle = "Titre du TB"


### PR DESCRIPTION
Hi,
That's me again, now that my TB has been released I have some free time again. I hope to contribute a few changes via different PRs as discussed previously.

That's the first PR introducing 2 new boolean vars to enable feminine forms of "Enseignante responsable" or "La soussignée" for all the text in the template.

```typ
#let TBfeminineForm = false // for the author
#let TBsupervisorFeminineForm = false // same, but for the supervisor.
```